### PR TITLE
Fix: 舰娘在捡起物品时可能造成复制

### DIFF
--- a/src/main/java/com/lulan/shincolle/ai/EntityAIShipPickItem.java
+++ b/src/main/java/com/lulan/shincolle/ai/EntityAIShipPickItem.java
@@ -6,7 +6,6 @@ import com.lulan.shincolle.entity.IShipEmotion;
 import com.lulan.shincolle.handler.ConfigHandler;
 import com.lulan.shincolle.reference.ID;
 import com.lulan.shincolle.utility.TargetHelper;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.item.EntityItem;
@@ -28,7 +27,7 @@ public class EntityAIShipPickItem extends EntityAIBase
     private BasicEntityShip hostShip;
     private BasicEntityMount hostMount;
     private EntityLivingBase hostLiving;
-    private Entity entItem;
+    private EntityItem entItem;
     private int pickDelay, pickDelayMax;
     private float pickRange, pickRangeBase;
     
@@ -130,8 +129,8 @@ public class EntityAIShipPickItem extends EntityAIBase
     		}//end every 16 ticks
 			
     		//pick up nearby item
-    		if (this.pickDelay <= 0 && this.entItem != null)
-    		{
+    		if (this.pickDelay <= 0 && this.entItem != null && !this.entItem.isDead)
+				{
     			this.pickDelay = this.pickDelayMax;
     			
     			//get item if close to 9D (3 blocks)
@@ -139,11 +138,10 @@ public class EntityAIShipPickItem extends EntityAIBase
     				(this.hostShip != null && this.hostShip.getDistanceSq(this.entItem) < 9D))
     			{
     				//add item to inventory
-    				EntityItem entitem = (EntityItem) this.entItem;
-    				ItemStack itemstack = entitem.getItem();
+    				ItemStack itemstack = entItem.getItem();
     				int i = itemstack.getCount();
     				
-    				if (!entitem.cannotPickup() &&
+    				if (!entItem.cannotPickup() &&
     					this.hostShip.getCapaShipInventory().addItemStackToInventory(itemstack))
     				{
     					//play pick item sound
@@ -159,7 +157,7 @@ public class EntityAIShipPickItem extends EntityAIBase
             			}
         				
     					//send item pickup sync packet
-    					this.hostShip.onItemPickup(entitem, i);
+    					this.hostShip.onItemPickup(entItem, i);
     					
     					//send attack time packet
     					this.hostShip.applyParticleAtAttacker(0, null, null);
@@ -170,7 +168,7 @@ public class EntityAIShipPickItem extends EntityAIBase
     					//clear entity item if no leftover item
     	                if (itemstack.getCount() <= 0)
     	                {
-    	                	entitem.setDead();
+    	                	entItem.setDead();
     	                	this.entItem = null;
     	                }
     				}


### PR DESCRIPTION
原逻辑是
1. 扫描附近物品
2. 走过去
3. 尝试捡起

但是在走过去和尝试捡起的过程中，物品可能已经被销毁或捡起。由于保留了EntityItem引用，舰娘仍会创建一份ItemStack的复制并加入Inventory。
修复：在捡起之前再次检查EntityItem.isDead以确保其没有被移除。