### PR TITLE
修复issue#9中的错误

### DIFF
--- a/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
+++ b/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
@@ -437,7 +437,9 @@ public class BasicEntityItem extends Entity {
             //if can pick
             if (this.delayBeforeCanPickup <= 0) {
                 //申明需要判断是否播放音效的变量
-                String pid1 String pid2 boolean NeedJudge = false
+                String pid1;
+                String pid2;
+                boolean NeedJudge = false;
                 //is OP
                 if (EntityHelper.checkOP(player)) {
                     player.inventory.addItemStackToInventory(itemstack);
@@ -466,7 +468,7 @@ public class BasicEntityItem extends Entity {
                                 }
                             } else {
                                 //需要判断是否为所有者
-                                NeedJudge = true
+                                NeedJudge = true;
                                 if (pid1.equals(pid2)) {
                                     player.inventory.addItemStackToInventory(itemstack);
                                 }

--- a/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
+++ b/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
@@ -474,35 +474,34 @@ public class BasicEntityItem extends Entity {
                                 }
                             }
                         }
-                        //ship egg w/o tag
-                        else {
-                            player.inventory.addItemStackToInventory(itemstack);
-                        }
                     }
-                    //not ship spawn egg
+                    //ship egg w/o tag
                     else {
                         player.inventory.addItemStackToInventory(itemstack);
                     }
                 }
-
-                //play pick sound
-                if (!this.isSilent() && !NeedJudge) {
-
-                    this.world.playSound((EntityPlayer) null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
-                }
-            } else {
-                if (pid1.equals(pid2)) {
-                    this.world.playSound((EntityPlayer) null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+                //not ship spawn egg
+                    else{
+                    player.inventory.addItemStackToInventory(itemstack);
                 }
             }
-        }//end delay = 0
 
-        if (itemstack.getCount() <= 0) {
-            this.setDead();
-        }
-    }//end server side
+            //play pick sound
+            if (!this.isSilent() && !NeedJudge) {
 
-}
+                this.world.playSound((EntityPlayer) null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+            }
+        } else {
+            if (pid1.equals(pid2)) {
+                this.world.playSound((EntityPlayer) null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+            }//end delay = 0
+
+            if (itemstack.getCount() <= 0) {
+                this.setDead();
+            }
+        }//end server side
+
+    }
 
     @Override
     protected void readEntityFromNBT(NBTTagCompound nbt) {

--- a/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
+++ b/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
@@ -28,155 +28,171 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nullable;
 import java.util.List;
 
-/**
- * custom entity item with:
- * 1. owner checking
- * 2. custom model
- * 3. fire proof
- * 4. no clip
- * 5. can't be pushed
+/** custom entity item with:
+ *  1. owner checking
+ *  2. custom model
+ *  3. fire proof
+ *  4. no clip
+ *  5. can't be pushed
+ * 
  */
-public class BasicEntityItem extends Entity {
-
-    /**
-     * item of this entity
-     */
+public class BasicEntityItem extends Entity
+{
+	
+	/** item of this entity */
     private static final DataParameter<ItemStack> ITEM = EntityDataManager.<ItemStack>createKey(EntityItem.class, DataSerializers.ITEM_STACK);
-    /**
-     * The age of this EntityItem (used to animate it up and down as well as expire it)
-     */
+    /** The age of this EntityItem (used to animate it up and down as well as expire it) */
     private int delayBeforeCanPickup;
     private String owner;  //TODO checking owner
-
-
-    public BasicEntityItem(World world) {
-        super(world);
-        this.setSize(0.8F, 0.8F);
-    }
-
-    public BasicEntityItem(World world, double x, double y, double z, ItemStack item) {
-        this(world);
-        this.setPosition(x, y, z);
-        this.motionX = 0D;
-        this.motionY = 0D;
-        this.motionZ = 0D;
-        this.isImmuneToFire = true;
-        this.onGround = true;
-        this.noClip = false;
-        this.delayBeforeCanPickup = 10;
-        this.setEntityItemStack(item);
-
-        //stop vanilla init
-        this.firstUpdate = false;
-    }
-
-    //新增item data到data watcher中
-    @Override
-    protected void entityInit() {
+	
+	
+	public BasicEntityItem(World world)
+	{
+		super(world);
+		this.setSize(0.8F, 0.8F);
+	}
+	
+	public BasicEntityItem(World world, double x, double y, double z, ItemStack item)
+	{
+		this(world);
+		this.setPosition(x, y, z);
+		this.motionX = 0D;
+		this.motionY = 0D;
+		this.motionZ = 0D;
+		this.isImmuneToFire = true;
+		this.onGround = true;
+		this.noClip = false;
+		this.delayBeforeCanPickup = 10;
+		this.setEntityItemStack(item);
+		
+		//stop vanilla init
+		this.firstUpdate = false;
+	}
+	
+	//新增item data到data watcher中
+	@Override
+    protected void entityInit()
+    {
         this.getDataManager().register(ITEM, ItemStack.EMPTY);
     }
-
-    //此entity不會走動
-    @Override
-    protected boolean canTriggerWalking() {
+	
+	//此entity不會走動
+	@Override
+    protected boolean canTriggerWalking()
+    {
         return false;
     }
-
-    //can not damage this item
-    @Override
-    public boolean attackEntityFrom(DamageSource attacker, float dmg) {
+	
+	//can not damage this item
+	@Override
+	public boolean attackEntityFrom(DamageSource attacker, float dmg)
+	{
+		return false;
+	}
+	
+	@Override
+    public boolean canBeAttackedWithItem()
+    {
         return false;
     }
-
-    @Override
-    public boolean canBeAttackedWithItem() {
-        return false;
-    }
-
-    @Override
-    public Entity changeDimension(int dimensionIn) {
-        return null;
-    }
-
-    public String getOwner() {
+	
+	@Override
+	public Entity changeDimension(int dimensionIn)
+	{
+		return null;
+	}
+	
+    public String getOwner()
+    {
         return this.owner;
     }
 
-    public void setOwner(String owner) {
+    public void setOwner(String owner)
+    {
         this.owner = owner;
     }
-
-    //cancel motionY
-    @Override
-    public void onUpdate() {
-        //client side
-        if (this.world.isRemote) {
-            //play portal sound
-            if ((this.ticksExisted & 31) == 0 && rand.nextInt(3) == 0) {
-                this.world.playSound(posX + 0.5D, posY + 0.5D, posZ + 0.5D, SoundEvents.BLOCK_PORTAL_AMBIENT, SoundCategory.BLOCKS, 0.5F, rand.nextFloat() * 0.4F + 0.8F, false);
-            }
-        }
-        //server side
-        else {
-            //despawn ship mob egg
-            if (this.ticksExisted > ConfigHandler.despawnEgg) {
-                ItemStack stack = this.getEntityItem();
-
-                if (!stack.hasTagCompound()) {
-                    this.setDead();
-                }
-            }
-        }
-
-        this.setPosition(posX, posY, posZ);
-
-        if (this.getEntityItem().isEmpty()) {
-            this.setDead();
-        } else {
-            //stop motion
-            this.prevPosX = this.posX;
-            this.prevPosY = this.posY;
-            this.prevPosZ = this.posZ;
-            this.motionX *= 0.5D;
-            this.motionY *= 0.5D;
-            this.motionZ *= 0.5D;
-            this.noClip = this.pushOutOfBlocks(this.posX, (this.getEntityBoundingBox().minY + this.getEntityBoundingBox().maxY) / 2.0D, this.posZ);
+	
+	//cancel motionY
+	@Override
+    public void onUpdate()
+    {
+		//client side
+		if (this.world.isRemote)
+		{
+			//play portal sound
+			if ((this.ticksExisted & 31) == 0 && rand.nextInt(3) == 0)
+	        {
+	            this.world.playSound(posX + 0.5D, posY + 0.5D, posZ + 0.5D, SoundEvents.BLOCK_PORTAL_AMBIENT, SoundCategory.BLOCKS, 0.5F, rand.nextFloat() * 0.4F + 0.8F, false);
+	        }
+		}
+		//server side
+		else
+		{
+			//despawn ship mob egg
+			if (this.ticksExisted > ConfigHandler.despawnEgg)
+			{
+				ItemStack stack = this.getEntityItem();
+				
+				if (!stack.hasTagCompound())
+				{
+					this.setDead();
+				}
+			}
+		}
+		
+		this.setPosition(posX, posY, posZ);
+		
+		if(this.getEntityItem().isEmpty())
+		{
+			this.setDead();
+		}
+		else
+		{
+			//stop motion
+			this.prevPosX = this.posX;
+			this.prevPosY = this.posY;
+			this.prevPosZ = this.posZ;
+			this.motionX *= 0.5D;
+			this.motionY *= 0.5D;
+			this.motionZ *= 0.5D;
+			this.noClip = this.pushOutOfBlocks(this.posX, (this.getEntityBoundingBox().minY + this.getEntityBoundingBox().maxY) / 2.0D, this.posZ);
             this.move(MoverType.SELF, this.motionX, this.motionY, this.motionZ);
+            
+			//check item
+			ItemStack item = this.getEntityItem();
+  
+			if (!item.isEmpty() && item.getCount() <= 0)
+			{
+				this.setDead();
+			}
+		}
 
-            //check item
-            ItemStack item = this.getEntityItem();
-
-            if (!item.isEmpty() && item.getCount() <= 0) {
-                this.setDead();
-            }
-        }
-
-        //pick delay --
-        if (this.delayBeforeCanPickup > 0) {
+		//pick delay --
+        if (this.delayBeforeCanPickup > 0)
+        {
             --this.delayBeforeCanPickup;
         }
     }
+	
+	//immune to fire and lava
+	@Override
+	protected void dealFireDamage(int fire) {}
+	
+	@Override
+	public void setFire(int time) {}
+	
+	@Override
+	protected void setOnFireFromLava() {}
 
-    //immune to fire and lava
-    @Override
-    protected void dealFireDamage(int fire) {
-    }
-
-    @Override
-    public void setFire(int time) {
-    }
-
-    @Override
-    protected void setOnFireFromLava() {
-    }
-
-    @Override
-    public boolean handleWaterMovement() {
-        return false;
-    }
-
-    @Override
-    public void move(MoverType type, double x, double y, double z) {
+	@Override
+	public boolean handleWaterMovement()
+	{
+		return false;
+	}
+	
+	@Override
+	public void move(MoverType type, double x, double y, double z)
+	{
         this.world.profiler.startSection("move");
         double d0 = this.posX;
         double d1 = this.posY;
@@ -187,44 +203,67 @@ public class BasicEntityItem extends Entity {
         double d6;
 
         //move x when collision onGround
-        for (d6 = 0.05D; x != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(x, -1.0D, 0.0D)).isEmpty(); d3 = x) {
-            if (x < d6 && x >= -d6) {
+        for (d6 = 0.05D; x != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(x, -1.0D, 0.0D)).isEmpty(); d3 = x)
+        {
+            if (x < d6 && x >= -d6)
+            {
                 x = 0.0D;
-            } else if (x > 0.0D) {
+            }
+            else if (x > 0.0D)
+            {
                 x -= d6;
-            } else {
+            }
+            else
+            {
                 x += d6;
             }
         }
 
         //move z when collision onGround
-        for (; z != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(0.0D, -1.0D, z)).isEmpty(); d5 = z) {
-            if (z < d6 && z >= -d6) {
+        for (; z != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(0.0D, -1.0D, z)).isEmpty(); d5 = z)
+        {
+            if (z < d6 && z >= -d6)
+            {
                 z = 0.0D;
-            } else if (z > 0.0D) {
+            }
+            else if (z > 0.0D)
+            {
                 z -= d6;
-            } else {
+            }
+            else
+            {
                 z += d6;
             }
         }
 
         //move xz when collision onGround
-        for (; x != 0.0D && z != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(x, -1.0D, z)).isEmpty(); d5 = z) {
-            if (x < d6 && x >= -d6) {
+        for (; x != 0.0D && z != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(x, -1.0D, z)).isEmpty(); d5 = z)
+        {
+            if (x < d6 && x >= -d6)
+            {
                 x = 0.0D;
-            } else if (x > 0.0D) {
+            }
+            else if (x > 0.0D)
+            {
                 x -= d6;
-            } else {
+            }
+            else
+            {
                 x += d6;
             }
 
             d3 = x;
 
-            if (z < d6 && z >= -d6) {
+            if (z < d6 && z >= -d6)
+            {
                 z = 0.0D;
-            } else if (z > 0.0D) {
+            }
+            else if (z > 0.0D)
+            {
                 z -= d6;
-            } else {
+            }
+            else
+            {
                 z += d6;
             }
         }
@@ -234,58 +273,65 @@ public class BasicEntityItem extends Entity {
         AxisAlignedBB axisalignedbb = this.getEntityBoundingBox();
         int i = 0;
 
-        for (int j = list1.size(); i < j; ++i) {
-            y = ((AxisAlignedBB) list1.get(i)).calculateYOffset(this.getEntityBoundingBox(), y);
+        for (int j = list1.size(); i < j; ++i)
+        {
+            y = ((AxisAlignedBB)list1.get(i)).calculateYOffset(this.getEntityBoundingBox(), y);
         }
 
         this.setEntityBoundingBox(this.getEntityBoundingBox().offset(0.0D, y, 0.0D));
         int j4 = 0;
 
-        for (int k = list1.size(); j4 < k; ++j4) {
-            x = ((AxisAlignedBB) list1.get(j4)).calculateXOffset(this.getEntityBoundingBox(), x);
+        for (int k = list1.size(); j4 < k; ++j4)
+        {
+            x = ((AxisAlignedBB)list1.get(j4)).calculateXOffset(this.getEntityBoundingBox(), x);
         }
 
         this.setEntityBoundingBox(this.getEntityBoundingBox().offset(x, 0.0D, 0.0D));
         j4 = 0;
 
-        for (int k4 = list1.size(); j4 < k4; ++j4) {
-            z = ((AxisAlignedBB) list1.get(j4)).calculateZOffset(this.getEntityBoundingBox(), z);
+        for (int k4 = list1.size(); j4 < k4; ++j4)
+        {
+            z = ((AxisAlignedBB)list1.get(j4)).calculateZOffset(this.getEntityBoundingBox(), z);
         }
 
         this.setEntityBoundingBox(this.getEntityBoundingBox().offset(0.0D, 0.0D, z));
 
         //move entity Y by stepHeight if x,z moved
-        if (this.stepHeight > 0.0F && (d3 != x || d5 != z)) {
+        if (this.stepHeight > 0.0F && (d3 != x || d5 != z))
+        {
             double d11 = x;
             double d7 = y;
             double d8 = z;
             AxisAlignedBB axisalignedbb1 = this.getEntityBoundingBox();
             this.setEntityBoundingBox(axisalignedbb);
-            y = (double) this.stepHeight;
+            y = (double)this.stepHeight;
             List<AxisAlignedBB> list = this.world.getCollisionBoxes(this, this.getEntityBoundingBox().grow(d3, y, d5));
             AxisAlignedBB axisalignedbb2 = this.getEntityBoundingBox();
             AxisAlignedBB axisalignedbb3 = axisalignedbb2.grow(d3, 0.0D, d5);
             double d9 = y;
             int l = 0;
 
-            for (int i1 = list.size(); l < i1; ++l) {
-                d9 = ((AxisAlignedBB) list.get(l)).calculateYOffset(axisalignedbb3, d9);
+            for (int i1 = list.size(); l < i1; ++l)
+            {
+                d9 = ((AxisAlignedBB)list.get(l)).calculateYOffset(axisalignedbb3, d9);
             }
 
             axisalignedbb2 = axisalignedbb2.offset(0.0D, d9, 0.0D);
             double d15 = d3;
             int j1 = 0;
 
-            for (int k1 = list.size(); j1 < k1; ++j1) {
-                d15 = ((AxisAlignedBB) list.get(j1)).calculateXOffset(axisalignedbb2, d15);
+            for (int k1 = list.size(); j1 < k1; ++j1)
+            {
+                d15 = ((AxisAlignedBB)list.get(j1)).calculateXOffset(axisalignedbb2, d15);
             }
 
             axisalignedbb2 = axisalignedbb2.offset(d15, 0.0D, 0.0D);
             double d16 = d5;
             int l1 = 0;
 
-            for (int i2 = list.size(); l1 < i2; ++l1) {
-                d16 = ((AxisAlignedBB) list.get(l1)).calculateZOffset(axisalignedbb2, d16);
+            for (int i2 = list.size(); l1 < i2; ++l1)
+            {
+                d16 = ((AxisAlignedBB)list.get(l1)).calculateZOffset(axisalignedbb2, d16);
             }
 
             axisalignedbb2 = axisalignedbb2.offset(0.0D, 0.0D, d16);
@@ -293,36 +339,42 @@ public class BasicEntityItem extends Entity {
             double d17 = y;
             int j2 = 0;
 
-            for (int k2 = list.size(); j2 < k2; ++j2) {
-                d17 = ((AxisAlignedBB) list.get(j2)).calculateYOffset(axisalignedbb4, d17);
+            for (int k2 = list.size(); j2 < k2; ++j2)
+            {
+                d17 = ((AxisAlignedBB)list.get(j2)).calculateYOffset(axisalignedbb4, d17);
             }
 
             axisalignedbb4 = axisalignedbb4.offset(0.0D, d17, 0.0D);
             double d18 = d3;
             int l2 = 0;
 
-            for (int i3 = list.size(); l2 < i3; ++l2) {
-                d18 = ((AxisAlignedBB) list.get(l2)).calculateXOffset(axisalignedbb4, d18);
+            for (int i3 = list.size(); l2 < i3; ++l2)
+            {
+                d18 = ((AxisAlignedBB)list.get(l2)).calculateXOffset(axisalignedbb4, d18);
             }
 
             axisalignedbb4 = axisalignedbb4.offset(d18, 0.0D, 0.0D);
             double d19 = d5;
             int j3 = 0;
 
-            for (int k3 = list.size(); j3 < k3; ++j3) {
-                d19 = ((AxisAlignedBB) list.get(j3)).calculateZOffset(axisalignedbb4, d19);
+            for (int k3 = list.size(); j3 < k3; ++j3)
+            {
+                d19 = ((AxisAlignedBB)list.get(j3)).calculateZOffset(axisalignedbb4, d19);
             }
 
             axisalignedbb4 = axisalignedbb4.offset(0.0D, 0.0D, d19);
             double d20 = d15 * d15 + d16 * d16;
             double d10 = d18 * d18 + d19 * d19;
 
-            if (d20 > d10) {
+            if (d20 > d10)
+            {
                 x = d15;
                 z = d16;
                 y = -d9;
                 this.setEntityBoundingBox(axisalignedbb2);
-            } else {
+            }
+            else
+            {
                 x = d18;
                 z = d19;
                 y = -d17;
@@ -331,13 +383,15 @@ public class BasicEntityItem extends Entity {
 
             int l3 = 0;
 
-            for (int i4 = list.size(); l3 < i4; ++l3) {
-                y = ((AxisAlignedBB) list.get(l3)).calculateYOffset(this.getEntityBoundingBox(), y);
+            for (int i4 = list.size(); l3 < i4; ++l3)
+            {
+                y = ((AxisAlignedBB)list.get(l3)).calculateYOffset(this.getEntityBoundingBox(), y);
             }
 
             this.setEntityBoundingBox(this.getEntityBoundingBox().offset(0.0D, y, 0.0D));
 
-            if (d11 * d11 + d8 * d8 >= x * x + z * z) {
+            if (d11 * d11 + d8 * d8 >= x * x + z * z)
+            {
                 x = d11;
                 y = d7;
                 z = d8;
@@ -346,7 +400,7 @@ public class BasicEntityItem extends Entity {
         }
 
         this.world.profiler.endSection();
-
+        
         //rest motion
         this.world.profiler.startSection("rest");
         this.resetPositionToBB();
@@ -354,60 +408,67 @@ public class BasicEntityItem extends Entity {
         this.collidedVertically = d4 != y;
         this.collided = this.collidedHorizontally || this.collidedVertically;
 
-        if (d3 != x) {
+        if (d3 != x)
+        {
             this.motionX = 0D;
         }
-
-        if (d4 != y) {
-            this.motionY = 0D;
+        
+        if (d4 != y)
+        {
+        	this.motionY = 0D;
         }
 
-        if (d5 != z) {
+        if (d5 != z)
+        {
             this.motionZ = 0D;
         }
 
         this.world.profiler.endSection();
 
-    }
-
-    @Override
-    protected void updateFallState(double y, boolean onGroundIn, IBlockState state, BlockPos pos) {
-    }
-
-    @Override
-    public void fall(float distance, float damageMultiplier) {
-    }
-
-    @Override
-    @SideOnly(Side.CLIENT)
-    public boolean canRenderOnFire() {
+	}
+	
+	@Override
+	protected void updateFallState(double y, boolean onGroundIn, IBlockState state, BlockPos pos) {}
+	
+	@Override
+	public void fall(float distance, float damageMultiplier) {}
+	
+	@Override
+	@SideOnly(Side.CLIENT)
+    public boolean canRenderOnFire()
+	{
         return false;
     }
-
-    @Override
-    public boolean shouldRenderInPass(int pass) {
+	
+	@Override
+	public boolean shouldRenderInPass(int pass)
+	{
         return true;
     }
-
-    @Override
-    public boolean isInvisible() {
-        return false;
-    }
-
-    @Override
-    public void setInvisible(boolean par1) {
-    }
-
+	
+	@Override
+	public boolean isInvisible()
+	{
+		return false;
+	}
+	
+	@Override
+	public void setInvisible(boolean par1) {}
+	
     /**
      * Returns the ItemStack corresponding to the Entity (Note: if no item exists, will log an error but still return an
      * ItemStack containing Block.stone)
      */
-    public ItemStack getEntityItem() {
-        ItemStack itemstack = (ItemStack) (this.getDataManager().get(ITEM));
+    public ItemStack getEntityItem()
+    {
+        ItemStack itemstack = (ItemStack)(this.getDataManager().get(ITEM));
 
-        if (itemstack.isEmpty()) {
+        if (itemstack.isEmpty())
+        {
             return new ItemStack(Blocks.STONE);
-        } else {
+        }
+        else
+        {
             return itemstack;
         }
     }
@@ -415,127 +476,147 @@ public class BasicEntityItem extends Entity {
     /**
      * Sets the ItemStack for this entity
      */
-    public void setEntityItemStack(@Nullable ItemStack stack) {
+    public void setEntityItemStack(@Nullable ItemStack stack)
+    {
         this.getDataManager().set(ITEM, stack);
         this.getDataManager().setDirty(ITEM);
     }
-
-    /**
+	
+	/**
      * Called by a player entity when they collide with an entity
      */
-    @Override
-    public void onCollideWithPlayer(EntityPlayer player) {
-        if (!this.world.isRemote && !this.isDead) {
-            //check delay
-            if (this.delayBeforeCanPickup > 0) return;
-
-            //get item
-            EntityTracker entitytracker = ((WorldServer) this.world).getEntityTracker();
+	@Override
+    public void onCollideWithPlayer(EntityPlayer player)
+	{
+        if(!this.world.isRemote && !this.isDead)
+        {
+        	//check delay
+        	if (this.delayBeforeCanPickup > 0) return;
+        	
+        	//get item
+        	EntityTracker entitytracker = ((WorldServer)this.world).getEntityTracker();
             ItemStack itemstack = this.getEntityItem();
             int i = itemstack.getCount();
-
+            
             //if can pick
-            if (this.delayBeforeCanPickup <= 0) {
+            if (this.delayBeforeCanPickup <= 0)
+            {
                 //申明需要判断是否播放音效的变量
                 String pid1;
                 String pid2;
                 boolean NeedJudge = false;
                 //is OP
-                if (EntityHelper.checkOP(player)) {
-                    player.inventory.addItemStackToInventory(itemstack);
+                if (EntityHelper.checkOP(player))
+                {
+                	player.inventory.addItemStackToInventory(itemstack);
                 }
                 //not OP
-                else {
-                    //ship spawn egg = owner pick only
-                    if (itemstack.getItem() == ModItems.ShipSpawnEgg) {
-                        NBTTagCompound nbt = itemstack.getTagCompound();
-
-                        //ship egg with tag
-                        if (nbt != null) {
-                            pid1 = nbt.getString("ownername");
-                            pid2 = player.getName();
-
-                            //check player UID
-                            //if no owner name
-                            if (pid1 == null || pid1.length() <= 1) {
-                                //ship's player UID isn't inited (for ship before 1.7.10.rv22)
-                                //check player UUID
-                                String uuid1 = nbt.getString("owner");
-                                String uuid2 = player.getUniqueID().toString();
-
-                                if (uuid2.equals(uuid1)) {
-                                    player.inventory.addItemStackToInventory(itemstack);
-                                }
-                            } else {
+                else
+                {
+                	//ship spawn egg = owner pick only
+                    if (itemstack.getItem() == ModItems.ShipSpawnEgg)
+                    {
+                    	NBTTagCompound nbt = itemstack.getTagCompound();
+                    	
+                    	//ship egg with tag
+                    	if (nbt != null)
+                    	{
+                    		pid1 = nbt.getString("ownername");
+                    		pid2 = player.getName();
+                    		
+                    		//check player UID
+                    		//if no owner name
+                    		if (pid1 == null || pid1.length() <= 1)
+                    		{
+                    			//ship's player UID isn't inited (for ship before 1.7.10.rv22)
+                    			//check player UUID
+                    			String uuid1 = nbt.getString("owner");
+                    			String uuid2 = player.getUniqueID().toString();
+                    			
+                    			if (uuid2.equals(uuid1))
+                    			{
+                    				player.inventory.addItemStackToInventory(itemstack);
+                    			}
+                    		}
+                    		else
+                    		{
                                 //需要判断是否为所有者
                                 NeedJudge = true;
-                                if (pid1.equals(pid2)) {
-                                    player.inventory.addItemStackToInventory(itemstack);
-                                }
-                            }
-                        }
-                    //ship egg w/o tag
-                    else {
-                        player.inventory.addItemStackToInventory(itemstack);
+                    			if (pid1.equals(pid2))
+                    			{
+                    				player.inventory.addItemStackToInventory(itemstack);
+                    			}
+                    		}
+                    	}
+                    	//ship egg w/o tag
+                    	else
+                    	{
+                    		player.inventory.addItemStackToInventory(itemstack);
+                    	}
+                    }
+                    //not ship spawn egg
+                    else
+                    {
+                    	player.inventory.addItemStackToInventory(itemstack);
                     }
                 }
-                //not ship spawn egg
-                    else{
-                    player.inventory.addItemStackToInventory(itemstack);
-                }
-            }
-
-            //play pick sound
-            if (!this.isSilent() && !NeedJudge) {
-
-                this.world.playSound((EntityPlayer) null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
-            }
-        } else {
-            if (pid1.equals(pid2)) {
-                this.world.playSound((EntityPlayer) null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+            	
+            	//play pick sound
+                if (!this.isSilent() && !NeedJudge)
+                {
+                    this.world.playSound((EntityPlayer)null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+                } else if (!this.isSilent() && pid1.equals(pid2)) {
+                    this.world.playSound((EntityPlayer) null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
             }//end delay = 0
-
-            if (itemstack.getCount() <= 0) {
+            
+            if (itemstack.getCount() <= 0)
+            {
                 this.setDead();
             }
         }//end server side
-
     }
 
-    @Override
-    protected void readEntityFromNBT(NBTTagCompound nbt) {
+	@Override
+	protected void readEntityFromNBT(NBTTagCompound nbt)
+	{
         NBTTagCompound itemtag = nbt.getCompoundTag("Item");
         this.setEntityItemStack(new ItemStack(itemtag));
 
         ItemStack item = this.getDataManager().get(ITEM);
 
-        if (item.isEmpty() || item.getCount() <= 0) {
+        if(item.isEmpty() || item.getCount() <= 0)
+        {
             this.setDead();
         }
-
-        if (nbt.hasKey("PickupDelay")) {
+        
+        if (nbt.hasKey("PickupDelay"))
+        {
             this.delayBeforeCanPickup = nbt.getShort("PickupDelay");
         }
 
-        if (nbt.hasKey("Owner")) {
+        if (nbt.hasKey("Owner"))
+        {
             this.owner = nbt.getString("Owner");
         }
 
-    }
+	}
 
-    @Override
-    protected void writeEntityToNBT(NBTTagCompound nbt) {
-        if (!this.getEntityItem().isEmpty()) {
+	@Override
+	protected void writeEntityToNBT(NBTTagCompound nbt)
+	{
+        if (!this.getEntityItem().isEmpty())
+        {
             nbt.setTag("Item", this.getEntityItem().writeToNBT(new NBTTagCompound()));
         }
-
-        if (this.getOwner() != null) {
-            nbt.setString("Owner", this.owner);
+        
+        if (this.getOwner() != null)
+        {
+        	nbt.setString("Owner", this.owner);
         }
+        
+        nbt.setShort("PickupDelay", (short)this.delayBeforeCanPickup);
 
-        nbt.setShort("PickupDelay", (short) this.delayBeforeCanPickup);
-
-    }
-
-
+	}
+	
+	
 }

--- a/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
+++ b/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
@@ -556,10 +556,12 @@ public class BasicEntityItem extends Entity
                 }
             	
             	//play pick sound
-                if (!this.isSilent() && pid1.equals(pid2))
+                if (!this.isSilent())
                 {
-                    this.world.playSound((EntityPlayer)null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
-                }
+		    if(pid1.equals(pid2)){
+                        this.world.playSound((EntityPlayer)null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+                    }
+		}
             }//end delay = 0
             
             if (itemstack.getCount() <= 0)

--- a/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
+++ b/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
@@ -556,7 +556,7 @@ public class BasicEntityItem extends Entity
                 }
             	
             	//play pick sound
-                if (!this.isSilent())
+                if (!this.isSilent() && pid1.equals(pid2))
                 {
                     this.world.playSound((EntityPlayer)null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
                 }

--- a/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
+++ b/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
@@ -28,171 +28,155 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nullable;
 import java.util.List;
 
-/** custom entity item with:
- *  1. owner checking
- *  2. custom model
- *  3. fire proof
- *  4. no clip
- *  5. can't be pushed
- * 
+/**
+ * custom entity item with:
+ * 1. owner checking
+ * 2. custom model
+ * 3. fire proof
+ * 4. no clip
+ * 5. can't be pushed
  */
-public class BasicEntityItem extends Entity
-{
-	
-	/** item of this entity */
+public class BasicEntityItem extends Entity {
+
+    /**
+     * item of this entity
+     */
     private static final DataParameter<ItemStack> ITEM = EntityDataManager.<ItemStack>createKey(EntityItem.class, DataSerializers.ITEM_STACK);
-    /** The age of this EntityItem (used to animate it up and down as well as expire it) */
+    /**
+     * The age of this EntityItem (used to animate it up and down as well as expire it)
+     */
     private int delayBeforeCanPickup;
     private String owner;  //TODO checking owner
-	
-	
-	public BasicEntityItem(World world)
-	{
-		super(world);
-		this.setSize(0.8F, 0.8F);
-	}
-	
-	public BasicEntityItem(World world, double x, double y, double z, ItemStack item)
-	{
-		this(world);
-		this.setPosition(x, y, z);
-		this.motionX = 0D;
-		this.motionY = 0D;
-		this.motionZ = 0D;
-		this.isImmuneToFire = true;
-		this.onGround = true;
-		this.noClip = false;
-		this.delayBeforeCanPickup = 10;
-		this.setEntityItemStack(item);
-		
-		//stop vanilla init
-		this.firstUpdate = false;
-	}
-	
-	//新增item data到data watcher中
-	@Override
-    protected void entityInit()
-    {
+
+
+    public BasicEntityItem(World world) {
+        super(world);
+        this.setSize(0.8F, 0.8F);
+    }
+
+    public BasicEntityItem(World world, double x, double y, double z, ItemStack item) {
+        this(world);
+        this.setPosition(x, y, z);
+        this.motionX = 0D;
+        this.motionY = 0D;
+        this.motionZ = 0D;
+        this.isImmuneToFire = true;
+        this.onGround = true;
+        this.noClip = false;
+        this.delayBeforeCanPickup = 10;
+        this.setEntityItemStack(item);
+
+        //stop vanilla init
+        this.firstUpdate = false;
+    }
+
+    //新增item data到data watcher中
+    @Override
+    protected void entityInit() {
         this.getDataManager().register(ITEM, ItemStack.EMPTY);
     }
-	
-	//此entity不會走動
-	@Override
-    protected boolean canTriggerWalking()
-    {
+
+    //此entity不會走動
+    @Override
+    protected boolean canTriggerWalking() {
         return false;
     }
-	
-	//can not damage this item
-	@Override
-	public boolean attackEntityFrom(DamageSource attacker, float dmg)
-	{
-		return false;
-	}
-	
-	@Override
-    public boolean canBeAttackedWithItem()
-    {
+
+    //can not damage this item
+    @Override
+    public boolean attackEntityFrom(DamageSource attacker, float dmg) {
         return false;
     }
-	
-	@Override
-	public Entity changeDimension(int dimensionIn)
-	{
-		return null;
-	}
-	
-    public String getOwner()
-    {
+
+    @Override
+    public boolean canBeAttackedWithItem() {
+        return false;
+    }
+
+    @Override
+    public Entity changeDimension(int dimensionIn) {
+        return null;
+    }
+
+    public String getOwner() {
         return this.owner;
     }
 
-    public void setOwner(String owner)
-    {
+    public void setOwner(String owner) {
         this.owner = owner;
     }
-	
-	//cancel motionY
-	@Override
-    public void onUpdate()
-    {
-		//client side
-		if (this.world.isRemote)
-		{
-			//play portal sound
-			if ((this.ticksExisted & 31) == 0 && rand.nextInt(3) == 0)
-	        {
-	            this.world.playSound(posX + 0.5D, posY + 0.5D, posZ + 0.5D, SoundEvents.BLOCK_PORTAL_AMBIENT, SoundCategory.BLOCKS, 0.5F, rand.nextFloat() * 0.4F + 0.8F, false);
-	        }
-		}
-		//server side
-		else
-		{
-			//despawn ship mob egg
-			if (this.ticksExisted > ConfigHandler.despawnEgg)
-			{
-				ItemStack stack = this.getEntityItem();
-				
-				if (!stack.hasTagCompound())
-				{
-					this.setDead();
-				}
-			}
-		}
-		
-		this.setPosition(posX, posY, posZ);
-		
-		if(this.getEntityItem().isEmpty())
-		{
-			this.setDead();
-		}
-		else
-		{
-			//stop motion
-			this.prevPosX = this.posX;
-			this.prevPosY = this.posY;
-			this.prevPosZ = this.posZ;
-			this.motionX *= 0.5D;
-			this.motionY *= 0.5D;
-			this.motionZ *= 0.5D;
-			this.noClip = this.pushOutOfBlocks(this.posX, (this.getEntityBoundingBox().minY + this.getEntityBoundingBox().maxY) / 2.0D, this.posZ);
-            this.move(MoverType.SELF, this.motionX, this.motionY, this.motionZ);
-            
-			//check item
-			ItemStack item = this.getEntityItem();
-  
-			if (!item.isEmpty() && item.getCount() <= 0)
-			{
-				this.setDead();
-			}
-		}
 
-		//pick delay --
-        if (this.delayBeforeCanPickup > 0)
-        {
+    //cancel motionY
+    @Override
+    public void onUpdate() {
+        //client side
+        if (this.world.isRemote) {
+            //play portal sound
+            if ((this.ticksExisted & 31) == 0 && rand.nextInt(3) == 0) {
+                this.world.playSound(posX + 0.5D, posY + 0.5D, posZ + 0.5D, SoundEvents.BLOCK_PORTAL_AMBIENT, SoundCategory.BLOCKS, 0.5F, rand.nextFloat() * 0.4F + 0.8F, false);
+            }
+        }
+        //server side
+        else {
+            //despawn ship mob egg
+            if (this.ticksExisted > ConfigHandler.despawnEgg) {
+                ItemStack stack = this.getEntityItem();
+
+                if (!stack.hasTagCompound()) {
+                    this.setDead();
+                }
+            }
+        }
+
+        this.setPosition(posX, posY, posZ);
+
+        if (this.getEntityItem().isEmpty()) {
+            this.setDead();
+        } else {
+            //stop motion
+            this.prevPosX = this.posX;
+            this.prevPosY = this.posY;
+            this.prevPosZ = this.posZ;
+            this.motionX *= 0.5D;
+            this.motionY *= 0.5D;
+            this.motionZ *= 0.5D;
+            this.noClip = this.pushOutOfBlocks(this.posX, (this.getEntityBoundingBox().minY + this.getEntityBoundingBox().maxY) / 2.0D, this.posZ);
+            this.move(MoverType.SELF, this.motionX, this.motionY, this.motionZ);
+
+            //check item
+            ItemStack item = this.getEntityItem();
+
+            if (!item.isEmpty() && item.getCount() <= 0) {
+                this.setDead();
+            }
+        }
+
+        //pick delay --
+        if (this.delayBeforeCanPickup > 0) {
             --this.delayBeforeCanPickup;
         }
     }
-	
-	//immune to fire and lava
-	@Override
-	protected void dealFireDamage(int fire) {}
-	
-	@Override
-	public void setFire(int time) {}
-	
-	@Override
-	protected void setOnFireFromLava() {}
 
-	@Override
-	public boolean handleWaterMovement()
-	{
-		return false;
-	}
-	
-	@Override
-	public void move(MoverType type, double x, double y, double z)
-	{
+    //immune to fire and lava
+    @Override
+    protected void dealFireDamage(int fire) {
+    }
+
+    @Override
+    public void setFire(int time) {
+    }
+
+    @Override
+    protected void setOnFireFromLava() {
+    }
+
+    @Override
+    public boolean handleWaterMovement() {
+        return false;
+    }
+
+    @Override
+    public void move(MoverType type, double x, double y, double z) {
         this.world.profiler.startSection("move");
         double d0 = this.posX;
         double d1 = this.posY;
@@ -203,67 +187,44 @@ public class BasicEntityItem extends Entity
         double d6;
 
         //move x when collision onGround
-        for (d6 = 0.05D; x != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(x, -1.0D, 0.0D)).isEmpty(); d3 = x)
-        {
-            if (x < d6 && x >= -d6)
-            {
+        for (d6 = 0.05D; x != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(x, -1.0D, 0.0D)).isEmpty(); d3 = x) {
+            if (x < d6 && x >= -d6) {
                 x = 0.0D;
-            }
-            else if (x > 0.0D)
-            {
+            } else if (x > 0.0D) {
                 x -= d6;
-            }
-            else
-            {
+            } else {
                 x += d6;
             }
         }
 
         //move z when collision onGround
-        for (; z != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(0.0D, -1.0D, z)).isEmpty(); d5 = z)
-        {
-            if (z < d6 && z >= -d6)
-            {
+        for (; z != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(0.0D, -1.0D, z)).isEmpty(); d5 = z) {
+            if (z < d6 && z >= -d6) {
                 z = 0.0D;
-            }
-            else if (z > 0.0D)
-            {
+            } else if (z > 0.0D) {
                 z -= d6;
-            }
-            else
-            {
+            } else {
                 z += d6;
             }
         }
 
         //move xz when collision onGround
-        for (; x != 0.0D && z != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(x, -1.0D, z)).isEmpty(); d5 = z)
-        {
-            if (x < d6 && x >= -d6)
-            {
+        for (; x != 0.0D && z != 0.0D && this.world.getCollisionBoxes(this, this.getEntityBoundingBox().offset(x, -1.0D, z)).isEmpty(); d5 = z) {
+            if (x < d6 && x >= -d6) {
                 x = 0.0D;
-            }
-            else if (x > 0.0D)
-            {
+            } else if (x > 0.0D) {
                 x -= d6;
-            }
-            else
-            {
+            } else {
                 x += d6;
             }
 
             d3 = x;
 
-            if (z < d6 && z >= -d6)
-            {
+            if (z < d6 && z >= -d6) {
                 z = 0.0D;
-            }
-            else if (z > 0.0D)
-            {
+            } else if (z > 0.0D) {
                 z -= d6;
-            }
-            else
-            {
+            } else {
                 z += d6;
             }
         }
@@ -273,65 +234,58 @@ public class BasicEntityItem extends Entity
         AxisAlignedBB axisalignedbb = this.getEntityBoundingBox();
         int i = 0;
 
-        for (int j = list1.size(); i < j; ++i)
-        {
-            y = ((AxisAlignedBB)list1.get(i)).calculateYOffset(this.getEntityBoundingBox(), y);
+        for (int j = list1.size(); i < j; ++i) {
+            y = ((AxisAlignedBB) list1.get(i)).calculateYOffset(this.getEntityBoundingBox(), y);
         }
 
         this.setEntityBoundingBox(this.getEntityBoundingBox().offset(0.0D, y, 0.0D));
         int j4 = 0;
 
-        for (int k = list1.size(); j4 < k; ++j4)
-        {
-            x = ((AxisAlignedBB)list1.get(j4)).calculateXOffset(this.getEntityBoundingBox(), x);
+        for (int k = list1.size(); j4 < k; ++j4) {
+            x = ((AxisAlignedBB) list1.get(j4)).calculateXOffset(this.getEntityBoundingBox(), x);
         }
 
         this.setEntityBoundingBox(this.getEntityBoundingBox().offset(x, 0.0D, 0.0D));
         j4 = 0;
 
-        for (int k4 = list1.size(); j4 < k4; ++j4)
-        {
-            z = ((AxisAlignedBB)list1.get(j4)).calculateZOffset(this.getEntityBoundingBox(), z);
+        for (int k4 = list1.size(); j4 < k4; ++j4) {
+            z = ((AxisAlignedBB) list1.get(j4)).calculateZOffset(this.getEntityBoundingBox(), z);
         }
 
         this.setEntityBoundingBox(this.getEntityBoundingBox().offset(0.0D, 0.0D, z));
 
         //move entity Y by stepHeight if x,z moved
-        if (this.stepHeight > 0.0F && (d3 != x || d5 != z))
-        {
+        if (this.stepHeight > 0.0F && (d3 != x || d5 != z)) {
             double d11 = x;
             double d7 = y;
             double d8 = z;
             AxisAlignedBB axisalignedbb1 = this.getEntityBoundingBox();
             this.setEntityBoundingBox(axisalignedbb);
-            y = (double)this.stepHeight;
+            y = (double) this.stepHeight;
             List<AxisAlignedBB> list = this.world.getCollisionBoxes(this, this.getEntityBoundingBox().grow(d3, y, d5));
             AxisAlignedBB axisalignedbb2 = this.getEntityBoundingBox();
             AxisAlignedBB axisalignedbb3 = axisalignedbb2.grow(d3, 0.0D, d5);
             double d9 = y;
             int l = 0;
 
-            for (int i1 = list.size(); l < i1; ++l)
-            {
-                d9 = ((AxisAlignedBB)list.get(l)).calculateYOffset(axisalignedbb3, d9);
+            for (int i1 = list.size(); l < i1; ++l) {
+                d9 = ((AxisAlignedBB) list.get(l)).calculateYOffset(axisalignedbb3, d9);
             }
 
             axisalignedbb2 = axisalignedbb2.offset(0.0D, d9, 0.0D);
             double d15 = d3;
             int j1 = 0;
 
-            for (int k1 = list.size(); j1 < k1; ++j1)
-            {
-                d15 = ((AxisAlignedBB)list.get(j1)).calculateXOffset(axisalignedbb2, d15);
+            for (int k1 = list.size(); j1 < k1; ++j1) {
+                d15 = ((AxisAlignedBB) list.get(j1)).calculateXOffset(axisalignedbb2, d15);
             }
 
             axisalignedbb2 = axisalignedbb2.offset(d15, 0.0D, 0.0D);
             double d16 = d5;
             int l1 = 0;
 
-            for (int i2 = list.size(); l1 < i2; ++l1)
-            {
-                d16 = ((AxisAlignedBB)list.get(l1)).calculateZOffset(axisalignedbb2, d16);
+            for (int i2 = list.size(); l1 < i2; ++l1) {
+                d16 = ((AxisAlignedBB) list.get(l1)).calculateZOffset(axisalignedbb2, d16);
             }
 
             axisalignedbb2 = axisalignedbb2.offset(0.0D, 0.0D, d16);
@@ -339,42 +293,36 @@ public class BasicEntityItem extends Entity
             double d17 = y;
             int j2 = 0;
 
-            for (int k2 = list.size(); j2 < k2; ++j2)
-            {
-                d17 = ((AxisAlignedBB)list.get(j2)).calculateYOffset(axisalignedbb4, d17);
+            for (int k2 = list.size(); j2 < k2; ++j2) {
+                d17 = ((AxisAlignedBB) list.get(j2)).calculateYOffset(axisalignedbb4, d17);
             }
 
             axisalignedbb4 = axisalignedbb4.offset(0.0D, d17, 0.0D);
             double d18 = d3;
             int l2 = 0;
 
-            for (int i3 = list.size(); l2 < i3; ++l2)
-            {
-                d18 = ((AxisAlignedBB)list.get(l2)).calculateXOffset(axisalignedbb4, d18);
+            for (int i3 = list.size(); l2 < i3; ++l2) {
+                d18 = ((AxisAlignedBB) list.get(l2)).calculateXOffset(axisalignedbb4, d18);
             }
 
             axisalignedbb4 = axisalignedbb4.offset(d18, 0.0D, 0.0D);
             double d19 = d5;
             int j3 = 0;
 
-            for (int k3 = list.size(); j3 < k3; ++j3)
-            {
-                d19 = ((AxisAlignedBB)list.get(j3)).calculateZOffset(axisalignedbb4, d19);
+            for (int k3 = list.size(); j3 < k3; ++j3) {
+                d19 = ((AxisAlignedBB) list.get(j3)).calculateZOffset(axisalignedbb4, d19);
             }
 
             axisalignedbb4 = axisalignedbb4.offset(0.0D, 0.0D, d19);
             double d20 = d15 * d15 + d16 * d16;
             double d10 = d18 * d18 + d19 * d19;
 
-            if (d20 > d10)
-            {
+            if (d20 > d10) {
                 x = d15;
                 z = d16;
                 y = -d9;
                 this.setEntityBoundingBox(axisalignedbb2);
-            }
-            else
-            {
+            } else {
                 x = d18;
                 z = d19;
                 y = -d17;
@@ -383,15 +331,13 @@ public class BasicEntityItem extends Entity
 
             int l3 = 0;
 
-            for (int i4 = list.size(); l3 < i4; ++l3)
-            {
-                y = ((AxisAlignedBB)list.get(l3)).calculateYOffset(this.getEntityBoundingBox(), y);
+            for (int i4 = list.size(); l3 < i4; ++l3) {
+                y = ((AxisAlignedBB) list.get(l3)).calculateYOffset(this.getEntityBoundingBox(), y);
             }
 
             this.setEntityBoundingBox(this.getEntityBoundingBox().offset(0.0D, y, 0.0D));
 
-            if (d11 * d11 + d8 * d8 >= x * x + z * z)
-            {
+            if (d11 * d11 + d8 * d8 >= x * x + z * z) {
                 x = d11;
                 y = d7;
                 z = d8;
@@ -400,7 +346,7 @@ public class BasicEntityItem extends Entity
         }
 
         this.world.profiler.endSection();
-        
+
         //rest motion
         this.world.profiler.startSection("rest");
         this.resetPositionToBB();
@@ -408,67 +354,60 @@ public class BasicEntityItem extends Entity
         this.collidedVertically = d4 != y;
         this.collided = this.collidedHorizontally || this.collidedVertically;
 
-        if (d3 != x)
-        {
+        if (d3 != x) {
             this.motionX = 0D;
         }
-        
-        if (d4 != y)
-        {
-        	this.motionY = 0D;
+
+        if (d4 != y) {
+            this.motionY = 0D;
         }
 
-        if (d5 != z)
-        {
+        if (d5 != z) {
             this.motionZ = 0D;
         }
 
         this.world.profiler.endSection();
 
-	}
-	
-	@Override
-	protected void updateFallState(double y, boolean onGroundIn, IBlockState state, BlockPos pos) {}
-	
-	@Override
-	public void fall(float distance, float damageMultiplier) {}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-    public boolean canRenderOnFire()
-	{
+    }
+
+    @Override
+    protected void updateFallState(double y, boolean onGroundIn, IBlockState state, BlockPos pos) {
+    }
+
+    @Override
+    public void fall(float distance, float damageMultiplier) {
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public boolean canRenderOnFire() {
         return false;
     }
-	
-	@Override
-	public boolean shouldRenderInPass(int pass)
-	{
+
+    @Override
+    public boolean shouldRenderInPass(int pass) {
         return true;
     }
-	
-	@Override
-	public boolean isInvisible()
-	{
-		return false;
-	}
-	
-	@Override
-	public void setInvisible(boolean par1) {}
-	
+
+    @Override
+    public boolean isInvisible() {
+        return false;
+    }
+
+    @Override
+    public void setInvisible(boolean par1) {
+    }
+
     /**
      * Returns the ItemStack corresponding to the Entity (Note: if no item exists, will log an error but still return an
      * ItemStack containing Block.stone)
      */
-    public ItemStack getEntityItem()
-    {
-        ItemStack itemstack = (ItemStack)(this.getDataManager().get(ITEM));
+    public ItemStack getEntityItem() {
+        ItemStack itemstack = (ItemStack) (this.getDataManager().get(ITEM));
 
-        if (itemstack.isEmpty())
-        {
+        if (itemstack.isEmpty()) {
             return new ItemStack(Blocks.STONE);
-        }
-        else
-        {
+        } else {
             return itemstack;
         }
     }
@@ -476,142 +415,127 @@ public class BasicEntityItem extends Entity
     /**
      * Sets the ItemStack for this entity
      */
-    public void setEntityItemStack(@Nullable ItemStack stack)
-    {
+    public void setEntityItemStack(@Nullable ItemStack stack) {
         this.getDataManager().set(ITEM, stack);
         this.getDataManager().setDirty(ITEM);
     }
-	
-	/**
+
+    /**
      * Called by a player entity when they collide with an entity
      */
-	@Override
-    public void onCollideWithPlayer(EntityPlayer player)
-	{
-        if(!this.world.isRemote && !this.isDead)
-        {
-        	//check delay
-        	if (this.delayBeforeCanPickup > 0) return;
-        	
-        	//get item
-        	EntityTracker entitytracker = ((WorldServer)this.world).getEntityTracker();
+    @Override
+    public void onCollideWithPlayer(EntityPlayer player) {
+        if (!this.world.isRemote && !this.isDead) {
+            //check delay
+            if (this.delayBeforeCanPickup > 0) return;
+
+            //get item
+            EntityTracker entitytracker = ((WorldServer) this.world).getEntityTracker();
             ItemStack itemstack = this.getEntityItem();
             int i = itemstack.getCount();
-            
+
             //if can pick
-            if (this.delayBeforeCanPickup <= 0)
-            {
+            if (this.delayBeforeCanPickup <= 0) {
+                //申明需要判断是否播放音效的变量
+                String pid1 String pid2 boolean NeedJudge = false
                 //is OP
-                if (EntityHelper.checkOP(player))
-                {
-                	player.inventory.addItemStackToInventory(itemstack);
+                if (EntityHelper.checkOP(player)) {
+                    player.inventory.addItemStackToInventory(itemstack);
                 }
                 //not OP
-                else
-                {
-                	//ship spawn egg = owner pick only
-                    if (itemstack.getItem() == ModItems.ShipSpawnEgg)
-                    {
-                    	NBTTagCompound nbt = itemstack.getTagCompound();
-                    	
-                    	//ship egg with tag
-                    	if (nbt != null)
-                    	{
-                    		String pid1 = nbt.getString("ownername");
-                    		String pid2 = player.getName();
-                    		
-                    		//check player UID
-                    		//if no owner name
-                    		if (pid1 == null || pid1.length() <= 1)
-                    		{
-                    			//ship's player UID isn't inited (for ship before 1.7.10.rv22)
-                    			//check player UUID
-                    			String uuid1 = nbt.getString("owner");
-                    			String uuid2 = player.getUniqueID().toString();
-                    			
-                    			if (uuid2.equals(uuid1))
-                    			{
-                    				player.inventory.addItemStackToInventory(itemstack);
-                    			}
-                    		}
-                    		else
-                    		{
-                    			if (pid1.equals(pid2))
-                    			{
-                    				player.inventory.addItemStackToInventory(itemstack);
-                    			}
-                    		}
-                    	}
-                    	//ship egg w/o tag
-                    	else
-                    	{
-                    		player.inventory.addItemStackToInventory(itemstack);
-                    	}
+                else {
+                    //ship spawn egg = owner pick only
+                    if (itemstack.getItem() == ModItems.ShipSpawnEgg) {
+                        NBTTagCompound nbt = itemstack.getTagCompound();
+
+                        //ship egg with tag
+                        if (nbt != null) {
+                            pid1 = nbt.getString("ownername");
+                            pid2 = player.getName();
+
+                            //check player UID
+                            //if no owner name
+                            if (pid1 == null || pid1.length() <= 1) {
+                                //ship's player UID isn't inited (for ship before 1.7.10.rv22)
+                                //check player UUID
+                                String uuid1 = nbt.getString("owner");
+                                String uuid2 = player.getUniqueID().toString();
+
+                                if (uuid2.equals(uuid1)) {
+                                    player.inventory.addItemStackToInventory(itemstack);
+                                }
+                            } else {
+                                //需要判断是否为所有者
+                                NeedJudge = true
+                                if (pid1.equals(pid2)) {
+                                    player.inventory.addItemStackToInventory(itemstack);
+                                }
+                            }
+                        }
+                        //ship egg w/o tag
+                        else {
+                            player.inventory.addItemStackToInventory(itemstack);
+                        }
                     }
                     //not ship spawn egg
-                    else
-                    {
-                    	player.inventory.addItemStackToInventory(itemstack);
+                    else {
+                        player.inventory.addItemStackToInventory(itemstack);
                     }
                 }
-            	
-            	//play pick sound
-                if (!this.isSilent())
-                {
-		    if(pid1.equals(pid2)){
-                        this.world.playSound((EntityPlayer)null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
-                    }
-		}
-            }//end delay = 0
-            
-            if (itemstack.getCount() <= 0)
-            {
-                this.setDead();
-            }
-        }//end server side
-    }
 
-	@Override
-	protected void readEntityFromNBT(NBTTagCompound nbt)
-	{
+                //play pick sound
+                if (!this.isSilent() && !NeedJudge) {
+
+                    this.world.playSound((EntityPlayer) null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+                }
+            } else {
+                if (pid1.equals(pid2)) {
+                    this.world.playSound((EntityPlayer) null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+                }
+            }
+        }//end delay = 0
+
+        if (itemstack.getCount() <= 0) {
+            this.setDead();
+        }
+    }//end server side
+
+}
+
+    @Override
+    protected void readEntityFromNBT(NBTTagCompound nbt) {
         NBTTagCompound itemtag = nbt.getCompoundTag("Item");
         this.setEntityItemStack(new ItemStack(itemtag));
 
         ItemStack item = this.getDataManager().get(ITEM);
 
-        if(item.isEmpty() || item.getCount() <= 0)
-        {
+        if (item.isEmpty() || item.getCount() <= 0) {
             this.setDead();
         }
-        
-        if (nbt.hasKey("PickupDelay"))
-        {
+
+        if (nbt.hasKey("PickupDelay")) {
             this.delayBeforeCanPickup = nbt.getShort("PickupDelay");
         }
 
-        if (nbt.hasKey("Owner"))
-        {
+        if (nbt.hasKey("Owner")) {
             this.owner = nbt.getString("Owner");
         }
 
-	}
+    }
 
-	@Override
-	protected void writeEntityToNBT(NBTTagCompound nbt)
-	{
-        if (!this.getEntityItem().isEmpty())
-        {
+    @Override
+    protected void writeEntityToNBT(NBTTagCompound nbt) {
+        if (!this.getEntityItem().isEmpty()) {
             nbt.setTag("Item", this.getEntityItem().writeToNBT(new NBTTagCompound()));
         }
-        
-        if (this.getOwner() != null)
-        {
-        	nbt.setString("Owner", this.owner);
-        }
-        
-        nbt.setShort("PickupDelay", (short)this.delayBeforeCanPickup);
 
-	}
-	
-	
+        if (this.getOwner() != null) {
+            nbt.setString("Owner", this.owner);
+        }
+
+        nbt.setShort("PickupDelay", (short) this.delayBeforeCanPickup);
+
+    }
+
+
 }

--- a/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
+++ b/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
@@ -34,74 +34,74 @@ import java.util.List;
  *  3. fire proof
  *  4. no clip
  *  5. can't be pushed
- * 
+ *
  */
 public class BasicEntityItem extends Entity
 {
-	
-	/** item of this entity */
+
+    /** item of this entity */
     private static final DataParameter<ItemStack> ITEM = EntityDataManager.<ItemStack>createKey(EntityItem.class, DataSerializers.ITEM_STACK);
     /** The age of this EntityItem (used to animate it up and down as well as expire it) */
     private int delayBeforeCanPickup;
     private String owner;  //TODO checking owner
-	
-	
-	public BasicEntityItem(World world)
-	{
-		super(world);
-		this.setSize(0.8F, 0.8F);
-	}
-	
-	public BasicEntityItem(World world, double x, double y, double z, ItemStack item)
-	{
-		this(world);
-		this.setPosition(x, y, z);
-		this.motionX = 0D;
-		this.motionY = 0D;
-		this.motionZ = 0D;
-		this.isImmuneToFire = true;
-		this.onGround = true;
-		this.noClip = false;
-		this.delayBeforeCanPickup = 10;
-		this.setEntityItemStack(item);
-		
-		//stop vanilla init
-		this.firstUpdate = false;
-	}
-	
-	//新增item data到data watcher中
-	@Override
+
+
+    public BasicEntityItem(World world)
+    {
+        super(world);
+        this.setSize(0.8F, 0.8F);
+    }
+
+    public BasicEntityItem(World world, double x, double y, double z, ItemStack item)
+    {
+        this(world);
+        this.setPosition(x, y, z);
+        this.motionX = 0D;
+        this.motionY = 0D;
+        this.motionZ = 0D;
+        this.isImmuneToFire = true;
+        this.onGround = true;
+        this.noClip = false;
+        this.delayBeforeCanPickup = 10;
+        this.setEntityItemStack(item);
+
+        //stop vanilla init
+        this.firstUpdate = false;
+    }
+
+    //新增item data到data watcher中
+    @Override
     protected void entityInit()
     {
         this.getDataManager().register(ITEM, ItemStack.EMPTY);
     }
-	
-	//此entity不會走動
-	@Override
+
+    //此entity不會走動
+    @Override
     protected boolean canTriggerWalking()
     {
         return false;
     }
-	
-	//can not damage this item
-	@Override
-	public boolean attackEntityFrom(DamageSource attacker, float dmg)
-	{
-		return false;
-	}
-	
-	@Override
+
+    //can not damage this item
+    @Override
+    public boolean attackEntityFrom(DamageSource attacker, float dmg)
+    {
+        return false;
+    }
+
+    @Override
     public boolean canBeAttackedWithItem()
     {
         return false;
     }
-	
-	@Override
-	public Entity changeDimension(int dimensionIn)
-	{
-		return null;
-	}
-	
+
+    @Override
+    public Entity changeDimension(int dimensionIn)
+    {
+        return null;
+    }
+
     public String getOwner()
     {
         return this.owner;
@@ -111,88 +111,88 @@ public class BasicEntityItem extends Entity
     {
         this.owner = owner;
     }
-	
-	//cancel motionY
-	@Override
+
+    //cancel motionY
+    @Override
     public void onUpdate()
     {
-		//client side
-		if (this.world.isRemote)
-		{
-			//play portal sound
-			if ((this.ticksExisted & 31) == 0 && rand.nextInt(3) == 0)
-	        {
-	            this.world.playSound(posX + 0.5D, posY + 0.5D, posZ + 0.5D, SoundEvents.BLOCK_PORTAL_AMBIENT, SoundCategory.BLOCKS, 0.5F, rand.nextFloat() * 0.4F + 0.8F, false);
-	        }
-		}
-		//server side
-		else
-		{
-			//despawn ship mob egg
-			if (this.ticksExisted > ConfigHandler.despawnEgg)
-			{
-				ItemStack stack = this.getEntityItem();
-				
-				if (!stack.hasTagCompound())
-				{
-					this.setDead();
-				}
-			}
-		}
-		
-		this.setPosition(posX, posY, posZ);
-		
-		if(this.getEntityItem().isEmpty())
-		{
-			this.setDead();
-		}
-		else
-		{
-			//stop motion
-			this.prevPosX = this.posX;
-			this.prevPosY = this.posY;
-			this.prevPosZ = this.posZ;
-			this.motionX *= 0.5D;
-			this.motionY *= 0.5D;
-			this.motionZ *= 0.5D;
-			this.noClip = this.pushOutOfBlocks(this.posX, (this.getEntityBoundingBox().minY + this.getEntityBoundingBox().maxY) / 2.0D, this.posZ);
-            this.move(MoverType.SELF, this.motionX, this.motionY, this.motionZ);
-            
-			//check item
-			ItemStack item = this.getEntityItem();
-  
-			if (!item.isEmpty() && item.getCount() <= 0)
-			{
-				this.setDead();
-			}
-		}
+        //client side
+        if (this.world.isRemote)
+        {
+            //play portal sound
+            if ((this.ticksExisted & 31) == 0 && rand.nextInt(3) == 0)
+            {
+                this.world.playSound(posX + 0.5D, posY + 0.5D, posZ + 0.5D, SoundEvents.BLOCK_PORTAL_AMBIENT, SoundCategory.BLOCKS, 0.5F, rand.nextFloat() * 0.4F + 0.8F, false);
+            }
+        }
+        //server side
+        else
+        {
+            //despawn ship mob egg
+            if (this.ticksExisted > ConfigHandler.despawnEgg)
+            {
+                ItemStack stack = this.getEntityItem();
 
-		//pick delay --
+                if (!stack.hasTagCompound())
+                {
+                    this.setDead();
+                }
+            }
+        }
+
+        this.setPosition(posX, posY, posZ);
+
+        if(this.getEntityItem().isEmpty())
+        {
+            this.setDead();
+        }
+        else
+        {
+            //stop motion
+            this.prevPosX = this.posX;
+            this.prevPosY = this.posY;
+            this.prevPosZ = this.posZ;
+            this.motionX *= 0.5D;
+            this.motionY *= 0.5D;
+            this.motionZ *= 0.5D;
+            this.noClip = this.pushOutOfBlocks(this.posX, (this.getEntityBoundingBox().minY + this.getEntityBoundingBox().maxY) / 2.0D, this.posZ);
+            this.move(MoverType.SELF, this.motionX, this.motionY, this.motionZ);
+
+            //check item
+            ItemStack item = this.getEntityItem();
+
+            if (!item.isEmpty() && item.getCount() <= 0)
+            {
+                this.setDead();
+            }
+        }
+
+        //pick delay --
         if (this.delayBeforeCanPickup > 0)
         {
             --this.delayBeforeCanPickup;
         }
     }
-	
-	//immune to fire and lava
-	@Override
-	protected void dealFireDamage(int fire) {}
-	
-	@Override
-	public void setFire(int time) {}
-	
-	@Override
-	protected void setOnFireFromLava() {}
 
-	@Override
-	public boolean handleWaterMovement()
-	{
-		return false;
-	}
-	
-	@Override
-	public void move(MoverType type, double x, double y, double z)
-	{
+    //immune to fire and lava
+    @Override
+    protected void dealFireDamage(int fire) {}
+
+    @Override
+    public void setFire(int time) {}
+
+    @Override
+    protected void setOnFireFromLava() {}
+
+    @Override
+    public boolean handleWaterMovement()
+    {
+        return false;
+    }
+
+    @Override
+    public void move(MoverType type, double x, double y, double z)
+    {
         this.world.profiler.startSection("move");
         double d0 = this.posX;
         double d1 = this.posY;
@@ -400,7 +400,7 @@ public class BasicEntityItem extends Entity
         }
 
         this.world.profiler.endSection();
-        
+
         //rest motion
         this.world.profiler.startSection("rest");
         this.resetPositionToBB();
@@ -412,10 +412,10 @@ public class BasicEntityItem extends Entity
         {
             this.motionX = 0D;
         }
-        
+
         if (d4 != y)
         {
-        	this.motionY = 0D;
+            this.motionY = 0D;
         }
 
         if (d5 != z)
@@ -425,36 +425,36 @@ public class BasicEntityItem extends Entity
 
         this.world.profiler.endSection();
 
-	}
-	
-	@Override
-	protected void updateFallState(double y, boolean onGroundIn, IBlockState state, BlockPos pos) {}
-	
-	@Override
-	public void fall(float distance, float damageMultiplier) {}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
+    }
+
+    @Override
+    protected void updateFallState(double y, boolean onGroundIn, IBlockState state, BlockPos pos) {}
+
+    @Override
+    public void fall(float distance, float damageMultiplier) {}
+
+    @Override
+    @SideOnly(Side.CLIENT)
     public boolean canRenderOnFire()
-	{
+    {
         return false;
     }
-	
-	@Override
-	public boolean shouldRenderInPass(int pass)
-	{
+
+    @Override
+    public boolean shouldRenderInPass(int pass)
+    {
         return true;
     }
-	
-	@Override
-	public boolean isInvisible()
-	{
-		return false;
-	}
-	
-	@Override
-	public void setInvisible(boolean par1) {}
-	
+
+    @Override
+    public boolean isInvisible()
+    {
+        return false;
+    }
+
+    @Override
+    public void setInvisible(boolean par1) {}
+
     /**
      * Returns the ItemStack corresponding to the Entity (Note: if no item exists, will log an error but still return an
      * ItemStack containing Block.stone)
@@ -481,23 +481,23 @@ public class BasicEntityItem extends Entity
         this.getDataManager().set(ITEM, stack);
         this.getDataManager().setDirty(ITEM);
     }
-	
-	/**
+
+    /**
      * Called by a player entity when they collide with an entity
      */
-	@Override
+    @Override
     public void onCollideWithPlayer(EntityPlayer player)
-	{
+    {
         if(!this.world.isRemote && !this.isDead)
         {
-        	//check delay
-        	if (this.delayBeforeCanPickup > 0) return;
-        	
-        	//get item
-        	EntityTracker entitytracker = ((WorldServer)this.world).getEntityTracker();
+            //check delay
+            if (this.delayBeforeCanPickup > 0) return;
+
+            //get item
+            EntityTracker entitytracker = ((WorldServer)this.world).getEntityTracker();
             ItemStack itemstack = this.getEntityItem();
             int i = itemstack.getCount();
-            
+
             //if can pick
             if (this.delayBeforeCanPickup <= 0)
             {
@@ -508,115 +508,116 @@ public class BasicEntityItem extends Entity
                 //is OP
                 if (EntityHelper.checkOP(player))
                 {
-                	player.inventory.addItemStackToInventory(itemstack);
+                    player.inventory.addItemStackToInventory(itemstack);
                 }
                 //not OP
                 else
                 {
-                	//ship spawn egg = owner pick only
+                    //ship spawn egg = owner pick only
                     if (itemstack.getItem() == ModItems.ShipSpawnEgg)
                     {
-                    	NBTTagCompound nbt = itemstack.getTagCompound();
-                    	
-                    	//ship egg with tag
-                    	if (nbt != null)
-                    	{
-                    		pid1 = nbt.getString("ownername");
-                    		pid2 = player.getName();
-                    		
-                    		//check player UID
-                    		//if no owner name
-                    		if (pid1 == null || pid1.length() <= 1)
-                    		{
-                    			//ship's player UID isn't inited (for ship before 1.7.10.rv22)
-                    			//check player UUID
-                    			String uuid1 = nbt.getString("owner");
-                    			String uuid2 = player.getUniqueID().toString();
-                    			
-                    			if (uuid2.equals(uuid1))
-                    			{
-                    				player.inventory.addItemStackToInventory(itemstack);
-                    			}
-                    		}
-                    		else
-                    		{
+                        NBTTagCompound nbt = itemstack.getTagCompound();
+
+                        //ship egg with tag
+                        if (nbt != null)
+                        {
+                            pid1 = nbt.getString("ownername");
+                            pid2 = player.getName();
+
+                            //check player UID
+                            //if no owner name
+                            if (pid1 == null || pid1.length() <= 1)
+                            {
+                                //ship's player UID isn't inited (for ship before 1.7.10.rv22)
+                                //check player UUID
+                                String uuid1 = nbt.getString("owner");
+                                String uuid2 = player.getUniqueID().toString();
+
+                                if (uuid2.equals(uuid1))
+                                {
+                                    player.inventory.addItemStackToInventory(itemstack);
+                                }
+                            }
+                            else
+                            {
                                 //需要判断是否为所有者
                                 NeedJudge = true;
-                    			if (pid1.equals(pid2))
-                    			{
-                    				player.inventory.addItemStackToInventory(itemstack);
-                    			}
-                    		}
-                    	}
-                    	//ship egg w/o tag
-                    	else
-                    	{
-                    		player.inventory.addItemStackToInventory(itemstack);
-                    	}
+                                if (pid1.equals(pid2))
+                                {
+                                    player.inventory.addItemStackToInventory(itemstack);
+                                }
+                            }
+                        }
+                        //ship egg w/o tag
+                        else
+                        {
+                            player.inventory.addItemStackToInventory(itemstack);
+                        }
                     }
                     //not ship spawn egg
                     else
                     {
-                    	player.inventory.addItemStackToInventory(itemstack);
+                        player.inventory.addItemStackToInventory(itemstack);
                     }
                 }
-            	
-            	//play pick sound
+
+                //play pick sound
                 if (!this.isSilent() && !NeedJudge)
                 {
                     this.world.playSound((EntityPlayer)null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
                 } else if (!this.isSilent() && pid1.equals(pid2)) {
                     this.world.playSound((EntityPlayer) null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((this.rand.nextFloat() - this.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
-            }//end delay = 0
-            
-            if (itemstack.getCount() <= 0)
+                }//end delay = 0
+
+                if (itemstack.getCount() <= 0)
+                {
+                    this.setDead();
+                }
+              }
+            }//end server side
+        }
+
+        @Override
+        protected void readEntityFromNBT(NBTTagCompound nbt)
+        {
+            NBTTagCompound itemtag = nbt.getCompoundTag("Item");
+            this.setEntityItemStack(new ItemStack(itemtag));
+
+            ItemStack item = this.getDataManager().get(ITEM);
+
+            if(item.isEmpty() || item.getCount() <= 0)
             {
                 this.setDead();
             }
-        }//end server side
+
+            if (nbt.hasKey("PickupDelay"))
+            {
+                this.delayBeforeCanPickup = nbt.getShort("PickupDelay");
+            }
+
+            if (nbt.hasKey("Owner"))
+            {
+                this.owner = nbt.getString("Owner");
+            }
+
+        }
+
+        @Override
+        protected void writeEntityToNBT(NBTTagCompound nbt)
+        {
+            if (!this.getEntityItem().isEmpty())
+            {
+                nbt.setTag("Item", this.getEntityItem().writeToNBT(new NBTTagCompound()));
+            }
+
+            if (this.getOwner() != null)
+            {
+                nbt.setString("Owner", this.owner);
+            }
+
+            nbt.setShort("PickupDelay", (short)this.delayBeforeCanPickup);
+
+        }
+
+
     }
-
-	@Override
-	protected void readEntityFromNBT(NBTTagCompound nbt)
-	{
-        NBTTagCompound itemtag = nbt.getCompoundTag("Item");
-        this.setEntityItemStack(new ItemStack(itemtag));
-
-        ItemStack item = this.getDataManager().get(ITEM);
-
-        if(item.isEmpty() || item.getCount() <= 0)
-        {
-            this.setDead();
-        }
-        
-        if (nbt.hasKey("PickupDelay"))
-        {
-            this.delayBeforeCanPickup = nbt.getShort("PickupDelay");
-        }
-
-        if (nbt.hasKey("Owner"))
-        {
-            this.owner = nbt.getString("Owner");
-        }
-
-	}
-
-	@Override
-	protected void writeEntityToNBT(NBTTagCompound nbt)
-	{
-        if (!this.getEntityItem().isEmpty())
-        {
-            nbt.setTag("Item", this.getEntityItem().writeToNBT(new NBTTagCompound()));
-        }
-        
-        if (this.getOwner() != null)
-        {
-        	nbt.setString("Owner", this.owner);
-        }
-        
-        nbt.setShort("PickupDelay", (short)this.delayBeforeCanPickup);
-
-	}
-	
-	
-}

--- a/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
+++ b/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
@@ -474,7 +474,6 @@ public class BasicEntityItem extends Entity {
                                 }
                             }
                         }
-                    }
                     //ship egg w/o tag
                     else {
                         player.inventory.addItemStackToInventory(itemstack);

--- a/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
+++ b/src/main/java/com/lulan/shincolle/item/BasicEntityItem.java
@@ -502,8 +502,8 @@ public class BasicEntityItem extends Entity
             if (this.delayBeforeCanPickup <= 0)
             {
                 //申明需要判断是否播放音效的变量
-                String pid1;
-                String pid2;
+                String pid1 = null;
+                String pid2 = null;
                 boolean NeedJudge = false;
                 //is OP
                 if (EntityHelper.checkOP(player))


### PR DESCRIPTION
可能是因为[BasicEntityItem.java](https://github.com/misaka10843/ShinColle/pull/10/commits/1cca0d50ddefa2a2c02b43642a469b20415406e4#diff-db5069339f34999bd333eb1f21396bc23bfc32cf06caefa14e5ed771de286734)的第`539`行判断是否为所有者时并未结束或者跳出，

导致在`559`行又没有判断是否为所有者而不是又不会销毁实体的情况下导致循环播放拾取音效

所以理论上只要将`559`行下面的`this.world.playSound((EntityPlayer)`添加判断即可